### PR TITLE
39 set jsonserializeroptions to allownamedfloatingpointliterals

### DIFF
--- a/OSPSuite.Utility.v3.ncrunchsolution
+++ b/OSPSuite.Utility.v3.ncrunchsolution
@@ -1,0 +1,8 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <AllowParallelTestExecution>False</AllowParallelTestExecution>
+    <EnableRDI>False</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/OSPSuite.Utility/Conversion/ByteArrayConverter.cs
+++ b/src/OSPSuite.Utility/Conversion/ByteArrayConverter.cs
@@ -1,25 +1,32 @@
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using OSPSuite.Utility.Extensions;
 
 namespace OSPSuite.Utility.Conversion
 {
    public class ByteArrayConverter
    {
+      private readonly JsonSerializerOptions _options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals };
+
+      public ByteArrayConverter()
+      {
+      }
+
       public byte[] ConvertToByteArray<T>(T[] arrayToConvert)
       {
          if (typeof(T).IsAnImplementationOf<byte>())
             return arrayToConvert as byte[];
 
-         return JsonSerializer.SerializeToUtf8Bytes(arrayToConvert);
+         return JsonSerializer.SerializeToUtf8Bytes(arrayToConvert, _options);
       }
 
       public T[] ConvertFromByteArray<T>(byte[] byteArray)
       {
          try
          {
-            return JsonSerializer.Deserialize<T[]>(byteArray);
+            return JsonSerializer.Deserialize<T[]>(byteArray, _options);
          }
          catch (JsonException)
          {

--- a/src/OSPSuite.Utility/Conversion/ByteArrayConverter.cs
+++ b/src/OSPSuite.Utility/Conversion/ByteArrayConverter.cs
@@ -10,10 +10,6 @@ namespace OSPSuite.Utility.Conversion
    {
       private readonly JsonSerializerOptions _options = new JsonSerializerOptions { NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals };
 
-      public ByteArrayConverter()
-      {
-      }
-
       public byte[] ConvertToByteArray<T>(T[] arrayToConvert)
       {
          if (typeof(T).IsAnImplementationOf<byte>())

--- a/tests/OSPSuite.Utility.Tests/ByteArrayConverterSpecs.cs
+++ b/tests/OSPSuite.Utility.Tests/ByteArrayConverterSpecs.cs
@@ -66,6 +66,10 @@ namespace OSPSuite.Utility.Tests
          {
             _doubleArray[i] = random.NextDouble() * 10;
          }
+
+         _doubleArray[0] = double.PositiveInfinity;
+         _doubleArray[1] = double.NegativeInfinity;
+         _doubleArray[2] = double.NaN;
       }
 
       protected override void Because()


### PR DESCRIPTION
Fixes #39

Check the issue for the stack trace. During qualification some serialization fails due to inf/nan. You need to set a specific property to serialize those using this new JSON based serializer