### PR TITLE
Downgrade System.Text.JSON

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -7,6 +7,7 @@ on:
  
 permissions:
   packages: read
+  contents: read
 
 env:
   MAJOR: 4

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
     - main
+ 
+permissions:
+  packages: read
 
 env:
   MAJOR: 4

--- a/src/OSPSuite.Utility/OSPSuite.Utility.csproj
+++ b/src/OSPSuite.Utility/OSPSuite.Utility.csproj
@@ -31,7 +31,7 @@
 
   
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
 </Project>

--- a/src/OSPSuite.Utility/OSPSuite.Utility.csproj
+++ b/src/OSPSuite.Utility/OSPSuite.Utility.csproj
@@ -14,6 +14,7 @@
     <Authors>Open-Systems-Pharmacolog</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   

--- a/src/OSPSuite.Utility/OSPSuite.Utility.csproj
+++ b/src/OSPSuite.Utility/OSPSuite.Utility.csproj
@@ -2,7 +2,7 @@
 
   
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <AssemblyName>OSPSuite.Utility</AssemblyName>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>


### PR DESCRIPTION
Fixes #42 
Fixes #41 

If we use the latest version of System.Text.JSON then we have to provide a `MyPackage.deps.json` file when using it with .NET 8. 

Since we use this atypical load scenario with rSharp to support running our .NET code from R we cannot rely on a `deps.json` file being available during assembly load and so we have to use the version that ships with the target framework.